### PR TITLE
Feature: Create Pool

### DIFF
--- a/programs/quadratic-funding/src/errors.rs
+++ b/programs/quadratic-funding/src/errors.rs
@@ -12,7 +12,7 @@ pub enum PoolError {
     ReleasedFunds,
 
     #[msg("This pool has already been cancelled")]
-    CancelledPool,
+    PoolClosed,
 
     #[msg("This pool is still active")]
     PoolStillActive,

--- a/programs/quadratic-funding/src/instructions/create_pool.rs
+++ b/programs/quadratic-funding/src/instructions/create_pool.rs
@@ -27,10 +27,9 @@ pub fn create_pool(
     name: String,
     description: String,
     author: Pubkey,
-    end_time: i32
+    end_time: i32,
     initial_amount: u64,
 ) -> Result<()> {
-    let authority = &mut ctx.accounts.authority;
     let pool = &mut ctx.accounts.pool;
 
     if name.len() > 50 {
@@ -47,7 +46,7 @@ pub fn create_pool(
         *ctx.bumps
             .get("pool")
             .expect("Should've gotten bump"),
-        authority.key(),
+        author,
         end_time,
         initial_amount,
     ));

--- a/programs/quadratic-funding/src/instructions/mod.rs
+++ b/programs/quadratic-funding/src/instructions/mod.rs
@@ -1,0 +1,3 @@
+pub mod create_pool;
+
+pub use create_pool::*;

--- a/programs/quadratic-funding/src/lib.rs
+++ b/programs/quadratic-funding/src/lib.rs
@@ -1,15 +1,29 @@
 use anchor_lang::prelude::*;
 
+pub mod errors;
+pub mod instructions;
+pub mod state;
+
+pub use errors::*;
+pub use instructions::*;
+pub use state::*;
+
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
 pub mod quadratic_funding {
     use super::*;
 
-    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+    pub fn create_pool(
+        ctx: Context<CreatePool>,
+        name: String,
+        description: String,
+        author: Pubkey,
+        end_time: i32,
+        initial_amount: u64,
+    ) -> Result<()> {
+        instructions::create_pool(ctx, name, description, author, end_time, initial_amount).expect("Failed to create pool.");
+
         Ok(())
     }
 }
-
-#[derive(Accounts)]
-pub struct Initialize {}

--- a/programs/quadratic-funding/src/state.rs
+++ b/programs/quadratic-funding/src/state.rs
@@ -1,8 +1,10 @@
 use anchor_lang::prelude::*;
 
+use crate::errors::*;
+
 #[account]
-#[derive(default)]
-pub struct Pool<'info> {
+#[derive(Default)]
+pub struct Pool {
     pub name: String,
     pub description: String,
     pub author: Pubkey,
@@ -20,6 +22,7 @@ impl Pool {
     pub fn new(
         name: String,
         description: String,
+        bump: u8,
         author: Pubkey,
         end_time: i32,
         initial_amount: u64,
@@ -27,10 +30,10 @@ impl Pool {
         Pool {
             name,
             description,
+            bump,
             author,
             end_time,
             initial_amount,
-            total_contributors = 0,
             ..Default::default()
         }
     }
@@ -45,13 +48,13 @@ impl Pool {
         let current_time = Clock::get()?.unix_timestamp;
         msg!("now: {}", current_time);
         msg!("End Time: {}", self.end_time);
-        if current_time > self.end_time {
+        if current_time > self.end_time.into() {
             return err!(PoolError::EndDatePassed)
         }
         match self.active {
             PoolState::Active => Ok(()),
             PoolState::Distributed => err!(PoolError::ReleasedFunds),
-            PoolState::Closed => err!(PoolError::ClosedPool),
+            PoolState::Closed => err!(PoolError::PoolClosed),
         }
     }
 }
@@ -64,8 +67,8 @@ pub enum PoolState {
     Closed,
 }
 
-impl Default for FundingState {
+impl Default for PoolState {
     fn default() -> Self {
-        FundingState::Active
+        PoolState::Active
     }
 }


### PR DESCRIPTION
Added a create_pool instruction to initialize an account for the QF pool. This can be used as an escrow vault in the future, with some tweaking. The account stores the following data:

- name: String
- description: String
- author: Pubkey
- end_time: i32
- initial_amount: u64
- total_contributors: u32
- active: PoolState (enum with options Active, Distributed, or Closed)
- bump: u8

Also added methods to close the pool, and check if it's active.
